### PR TITLE
Request for Comment (RFC): Add language defining "community spaces" to code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -51,11 +51,13 @@ decisions when appropriate.
 
 ## Scope
 
-This Code of Conduct applies within all community spaces, and also applies when
-an individual is officially representing the community in public spaces.
-Examples of representing our community include using an official e-mail address,
+This Code of Conduct applies within all community spaces such as discussions,
+bug reports (issues), commit messages, pull requests, and other spaces where
+community members interact. This Code of Conduct also applies when an 
+individual is officially representing the community in public spaces.
+Examples of representing our community include official responses through e-mail,
 posting via an official social media account, or acting as an appointed
-representative at an online or offline event.
+representative at an online or offline event such as a conference talk.
 
 ## Enforcement
 


### PR DESCRIPTION
The Code of Conduct's "Scope" section states that it applies within all community spaces, but that language may not be clear to all contributors.

This commit adds examples of the technical spaces where the CoC would apply such as bug reports, commit messages, etc. It also adds a conference talk as an example of an offline event where someone may be acting as an "appointed representative" for the group.

----
N.B. While this seems like a straightforward change, I think it's important to set some kind of expectation on when and how the CoC will change. It should be a living document that we can update as needed, but substantial changes should not be made without wider input. So in some ways, this is a test of such a process: 
* an atomic change that produces a nice diff
* a pull request to advertise the change
* public comment period
* Someone other than the proposer closes as success or failure